### PR TITLE
Hotfix

### DIFF
--- a/frontend/src/components/editor/editor-actions-buttons.vue
+++ b/frontend/src/components/editor/editor-actions-buttons.vue
@@ -87,7 +87,6 @@ import {
   ALGORITHMS_EDITOR,
   ALGORITHMS_MAINTENANCE_INDEX,
   ALGORITHMS_PUBLIC_EDITOR,
-  // ALGORITHMS_PUBLIC_EDITOR_PATH,
   ALGORITHMS_PUBLIC_SEARCH,
   ALGORITHMS_SEARCH,
 } from 'src/router/routes/algorithms';
@@ -173,8 +172,7 @@ const viewPublicGraph = async () => {
       await editor.graph.save();
     }
 
-    // await editor.switchToMode();
-    Editor.preview(route.query.id);
+    Editor.preview(Number(route.query.id));
   }
 };
 </script>

--- a/frontend/src/css/app.sass
+++ b/frontend/src/css/app.sass
@@ -166,7 +166,7 @@ g[data-type="LaneElement"] .element-textarea-input
 .editor-layout-footer
   z-index: 999
   position: absolute
-  bottom: 15px
-  left: 0
+  bottom: 0
+  left: 5px
   width: 400px
   height: 68px

--- a/frontend/src/css/editor.sass
+++ b/frontend/src/css/editor.sass
@@ -50,9 +50,9 @@
   #editor-actions-buttons
     z-index: 101
     position: absolute
-    bottom: 15px
+    bottom: 0
     left: 0
-    width: calc(100% - 15px)
+    width: 100%
     background-color: white
 
   #public-option

--- a/frontend/src/pages/editor/editor-page.vue
+++ b/frontend/src/pages/editor/editor-page.vue
@@ -197,7 +197,7 @@ onBeforeMount(async () => {
 
       await editor.init('editor-stage');
 
-      editor.graph.cropToContent(500, 600);
+      if (editor.data.readOnly) editor.graph.cropToContent(500, 600);
 
       settings.page.setTitle(editor.data.readOnly ? 'Publicación de algoritmo' : 'Editar algoritmo');
     } else {

--- a/frontend/src/pages/editor/editor-page.vue
+++ b/frontend/src/pages/editor/editor-page.vue
@@ -8,7 +8,7 @@
       <!--<div style="position:absolute">
         mode: {{ editor.graph.data.mode }} - read only: {{ editor.data.readOnly }}
       </div>-->
-      <editor-stage-header />
+      <editor-stage-header/>
 
       <zooming-bar
         class="absolute-top-right"
@@ -33,13 +33,13 @@
       />
 
       <!-- STAGE -->
-      <editor-stage />
+      <editor-stage/>
 
       <!-- METADATA -->
-      <editor-metadata-panel />
+      <editor-metadata-panel/>
 
       <!-- ACTIONS -->
-      <editor-actions-buttons />
+      <editor-actions-buttons/>
     </div>
 
     <simple-modal
@@ -89,7 +89,9 @@ import SimpleModal from 'components/modals/simple-modal.vue';
 
 import {
   ALGORITHMS_EDITOR,
-  ALGORITHMS_MAINTENANCE_INDEX, ALGORITHMS_PUBLIC_EDITOR, ALGORITHMS_PUBLIC_SEARCH,
+  ALGORITHMS_MAINTENANCE_INDEX,
+  ALGORITHMS_PUBLIC_EDITOR,
+  ALGORITHMS_PUBLIC_SEARCH,
   ALGORITHMS_SEARCH,
 } from 'src/router/routes/algorithms';
 import { GRAPH_MODE_EDIT, GRAPH_MODE_PUBLIC } from 'src/services/editor/types';
@@ -194,6 +196,8 @@ onBeforeMount(async () => {
       await editor.graph.open(id);
 
       await editor.init('editor-stage');
+
+      editor.graph.cropToContent(500, 600);
 
       settings.page.setTitle(editor.data.readOnly ? 'Publicación de algoritmo' : 'Editar algoritmo');
     } else {

--- a/frontend/src/pages/editor/editor-page.vue
+++ b/frontend/src/pages/editor/editor-page.vue
@@ -197,7 +197,11 @@ onBeforeMount(async () => {
 
       await editor.init('editor-stage');
 
-      if (editor.data.readOnly) editor.graph.cropToContent(500, 600);
+      if (editor.data.readOnly) {
+        editor.graph.cropToContent(500, 600);
+
+        editor.element.hideAllPorts();
+      }
 
       settings.page.setTitle(editor.data.readOnly ? 'Publicación de algoritmo' : 'Editar algoritmo');
     } else {

--- a/frontend/src/pages/editor/print-page.vue
+++ b/frontend/src/pages/editor/print-page.vue
@@ -64,9 +64,13 @@ onMounted(async () => {
     setTimeout(async () => {
       loading.value = false;
 
+      editor.element.hideAllPorts();
+
       editor.element.redrawAllConnections();
 
-      editor.graph.exportPDF();
+      editor.element.createElementsIndexes();
+
+      // editor.graph.exportPDF();
     }, 2000);
   }
 });

--- a/frontend/src/pages/editor/print-page.vue
+++ b/frontend/src/pages/editor/print-page.vue
@@ -57,7 +57,7 @@ onMounted(async () => {
 
     await editor.init('editor-stage');
 
-    await editor.graph.putLogoOnPdfHeader(putLogoOnHeader);
+    void editor.graph.putLogoOnPdfHeader(putLogoOnHeader);
 
     await editor.graph.setToPrint();
 
@@ -70,7 +70,7 @@ onMounted(async () => {
 
       editor.element.createElementsIndexes();
 
-      editor.graph.exportPDF();
+      // editor.graph.exportPDF();
     }, 2000);
   }
 });

--- a/frontend/src/pages/editor/print-page.vue
+++ b/frontend/src/pages/editor/print-page.vue
@@ -70,7 +70,7 @@ onMounted(async () => {
 
       editor.element.createElementsIndexes();
 
-      // editor.graph.exportPDF();
+      editor.graph.exportPDF();
     }, 2000);
   }
 });

--- a/frontend/src/services/editor/element.ts
+++ b/frontend/src/services/editor/element.ts
@@ -752,6 +752,8 @@ autores individuales, y la producción de algoritmos con esta herramienta no imp
         link.router('manhattan', {
           step: 10,
           padding: 40,
+          excludeTypes: ['standard.Rectangle'],
+          excludeEnds: ['source'],
         });
 
         link.connector('straight', {
@@ -789,7 +791,10 @@ autores individuales, y la producción de algoritmos con esta herramienta no imp
     // remove stroke from the selected element
     elements.forEach((element) => {
       // hide element tools
-      if (this.editor.data.paper && !this.editor.data.readOnly) {
+      if (
+        this.editor.data.paper
+        && !this.editor.data.readOnly
+      ) {
         element.findView(this.editor.data.paper).hideTools();
       } else if (this.editor.data.readOnly) {
         // this.createReadonlyTools(element, false);
@@ -1719,6 +1724,68 @@ autores individuales, y la producción de algoritmos con esta herramienta no imp
       element.prop('ports/groups/bottom/attrs/portBody/fill', 'transparent');
       element.prop('ports/groups/in/attrs/portBody/fill', 'transparent');
       element.prop('ports/groups/out/attrs/portBody/fill', 'transparent');
+    }
+  }
+
+  public hideAllPorts() {
+    const allElements = this.getAll();
+
+    for (const element of allElements) {
+      if (this.isAction(element) || this.isEvaluation(element)) {
+        this.hidePorts(element.id);
+      }
+    }
+  }
+
+  public createElementsIndexes() {
+    const allElements = this.editor.element.getAll();
+
+    if (allElements.length) {
+      let elementIndex = 1;
+
+      for (const element of allElements) {
+        const elementType = element.prop('type');
+
+        if ([
+          CustomElement.ACTION,
+          CustomElement.EVALUATION,
+        ].includes(elementType)) {
+          const {
+            x,
+            y,
+          } = element.position();
+
+          const metadata = this.editor.metadata.getFromElement(element);
+
+          if (metadata && metadata.fixed.length) {
+            const indexElement = new joint.shapes.standard.Rectangle();
+
+            if (elementType === CustomElement.ACTION) {
+              indexElement.position(x, y - 30);
+            } else if (elementType === CustomElement.EVALUATION) {
+              indexElement.position(x + 32, y - 28);
+            }
+
+            indexElement.attr('body/stroke', 'black');
+            indexElement.attr('body/strokeWidth', 1);
+            indexElement.attr('body/rx', 2);
+            indexElement.attr('body/ry', 2);
+            indexElement.attr('label/text', elementIndex);
+            indexElement.attr('label/text-anchor', 'center');
+            indexElement.attr('label/style', 'font-size: 16px; border: 1px solid #F00');
+            indexElement.attr('label/ref-x', elementIndex > 9 ? -9 : -5);
+            indexElement.attr('label/ref-y', 1);
+
+            indexElement.resize(24, 24);
+
+            indexElement.addTo(this.editor.data.graph);
+
+            element.prop('props/elementIndex', elementIndex);
+
+            elementIndex += 1;
+          }
+        }
+      }
     }
   }
 }

--- a/frontend/src/services/editor/graph.ts
+++ b/frontend/src/services/editor/graph.ts
@@ -125,16 +125,6 @@ class Graph {
             }, 200);
           }
 
-          // reset scroll because of createEventHandlers method
-          // that focus on input fields
-          // which changes the scroll
-          setTimeout(() => {
-            Editor.setScroll({ x: 0, y: 0 });
-
-            // this.editor.paperDiv?.classList.remove('hidden');
-            document.getElementById('stage-loading-spinner-cover')?.classList.add('hidden');
-          }, 1500);
-
           await this.editor.element.createAllRecommendationsTotals();
 
           // READ ONLY MODE
@@ -158,6 +148,19 @@ class Graph {
           }
         }
       }
+
+      // reset scroll because of createEventHandlers method
+      // that focus on input fields
+      // which changes the scroll
+      setTimeout(() => {
+        Editor.setScroll({ x: 0, y: 0 });
+
+        if (document.activeElement && document.activeElement instanceof HTMLElement) {
+          document.activeElement.blur();
+        }
+
+        document.getElementById('stage-loading-spinner-cover')?.classList.add('hidden');
+      }, 1500);
 
       return Promise.resolve(true);
     } catch (error) {

--- a/frontend/src/services/editor/graph.ts
+++ b/frontend/src/services/editor/graph.ts
@@ -134,7 +134,7 @@ class Graph {
 
             // this.editor.paperDiv?.classList.remove('hidden');
             document.getElementById('stage-loading-spinner-cover')?.classList.add('hidden');
-          }, 1000);
+          }, 1500);
 
           await this.editor.element.createAllRecommendationsTotals();
 
@@ -337,8 +337,8 @@ class Graph {
     }
   }
 
-  private cropToContent() {
-    this.setContentSize();
+  public cropToContent(shiftX = 200, shiftY = 200) {
+    this.setContentSize(shiftX, shiftY);
 
     this.editor.data.paper?.setDimensions(this.data.printSize.width, this.data.printSize.height);
   }
@@ -391,9 +391,9 @@ class Graph {
     return coordinate === 'x' ? outerX : lowerY;
   }
 
-  private setContentSize() {
-    this.data.printSize.width = this.getOutermostCoordinate('x') + 200;
-    this.data.printSize.height = this.getOutermostCoordinate('y') + 200;
+  private setContentSize(shiftX: number, shiftY: number) {
+    this.data.printSize.width = this.getOutermostCoordinate('x') + shiftX;
+    this.data.printSize.height = this.getOutermostCoordinate('y') + shiftY;
   }
 
   public exportPDF() {

--- a/frontend/src/services/editor/graph.ts
+++ b/frontend/src/services/editor/graph.ts
@@ -1,5 +1,4 @@
 import { reactive } from 'vue';
-import * as joint from 'jointjs';
 import { api } from 'boot/axios';
 import html2pdf from 'html2pdf.js';
 
@@ -154,7 +153,7 @@ class Graph {
                 this.editor.element.select(String(this.editor.route.query.node));
 
                 this.editor.element.centerViewOnSelected();
-              }, 1000);
+              }, 1501);
             }
           }
         }
@@ -248,8 +247,6 @@ class Graph {
     const allElements = this.editor.element.getAll();
 
     if (allElements.length) {
-      let elementIndex = 1;
-
       for (const element of allElements) {
         const elementType = element.prop('type');
 
@@ -272,35 +269,6 @@ class Graph {
             textarea.remove();
 
             this.editor.element.create.PrintLabel({ x, y, text: label });
-
-            const metadata = this.editor.metadata.getFromElement(element);
-
-            if (metadata && metadata.fixed.length) {
-              const indexElement = new joint.shapes.standard.Rectangle();
-
-              if (elementType === CustomElement.ACTION) {
-                indexElement.position(x, y - 30);
-              } else if (elementType === CustomElement.EVALUATION) {
-                indexElement.position(x + 32, y - 28);
-              }
-
-              indexElement.attr('body/stroke', 'black');
-              indexElement.attr('body/strokeWidth', 1);
-              indexElement.attr('body/rx', 2);
-              indexElement.attr('body/ry', 2);
-              indexElement.attr('label/text', elementIndex);
-              indexElement.attr('label/text-anchor', 'center');
-              indexElement.attr('label/style', 'font-size: 16px; border: 1px solid #F00');
-              indexElement.attr('label/ref-x', elementIndex > 9 ? -9 : -5);
-              indexElement.attr('label/ref-y', 1);
-
-              indexElement.resize(24, 24);
-              indexElement.addTo(this.editor.data.graph);
-
-              element.prop('props/elementIndex', elementIndex);
-
-              elementIndex += 1;
-            }
           }
         } else if (elementType === CustomElement.RECOMMENDATION_TOGGLER) {
           element.remove();
@@ -327,7 +295,7 @@ class Graph {
 
       await this.editor.element.createRecommendationsForPDF();
 
-      this.editor.element.moveAllElementsDown(200);
+      this.editor.element.moveAllElementsDown(250);
 
       this.cropToContent();
 

--- a/frontend/src/services/editor/index.ts
+++ b/frontend/src/services/editor/index.ts
@@ -192,29 +192,29 @@ class Editor {
         });
 
         this.data.paper.on('element:pointerup', (elementView: dia.ElementView) => {
-          if (elementView.options.model.prop('type') === CustomElement.RECOMMENDATION_TOGGLER) {
-            this.element.toggleRecommendation(elementView.options.model.id);
-          } else if (
-            // not in print mode (PDF export)
-            this.graph.data.mode !== GRAPH_MODE_PRINT
-            // do not select [lane, recommendation_toggler] element if it's in read only mode
-            && !(
-              this.data.readOnly
-              && elementView.options.model.prop('type') === CustomElement.LANE
-            )
-            // cannot interact with RECOMMENDATION_TOTAL elements at all
-            && elementView.options.model.prop('type') !== CustomElement.RECOMMENDATION_TOTAL
-          ) {
-            this.element.select(elementView.options.model.id);
-          }
+          // not in print mode (PDF export)
+          if (this.graph.data.mode !== GRAPH_MODE_PRINT) {
+            if (elementView.options.model.prop('type') === CustomElement.RECOMMENDATION_TOGGLER) {
+              this.element.toggleRecommendation(elementView.options.model.id);
+            } else if (
+              !(
+                this.data.readOnly
+                && elementView.options.model.prop('type') === CustomElement.LANE
+              )
+              // cannot interact with RECOMMENDATION_TOTAL elements at all
+              && elementView.options.model.prop('type') !== CustomElement.RECOMMENDATION_TOTAL
+            ) {
+              this.element.select(elementView.options.model.id);
+            }
 
-          // redraw recommendations totals after stop moving
-          if (this.element.data.wasMoving) {
-            this.element.updateRecommendationsTotals();
+            // redraw recommendations totals after stop moving
+            if (this.element.data.wasMoving) {
+              this.element.updateRecommendationsTotals();
 
-            this.element.data.wasMoving = false;
+              this.element.data.wasMoving = false;
 
-            this.element.redrawAllConnections();
+              this.element.redrawAllConnections();
+            }
           }
         });
 


### PR DESCRIPTION
- Acertar interferência de selos numeradores de nós com o cabeçalho;
- Ajustar melhor espaços livres em torno dos algoritmos, tanto em manutenção quanto em publicação;
- Ao entrar no algoritmo de "Zoonotic influenza", o nó de avaliação aparece com as portas (clicando-se neste nó, as portas desaparecem);
- Quando abrimos um a janela intermediária próxima ao rodapé, há uma interferência (o rodapé se sobrepõe);
- Comportamento errático em conectores com nós próximos e, na publicação, eles mudam de formato - e-mail do Ariel de 23/12/2024 - 9:18.